### PR TITLE
Scaffold blog & article

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -43,7 +43,7 @@
           <a href="/">Shop</a>
         </div>
         <div class="grid-item text-align-center">
-          <a href="/pages/program">Program</a>
+          <a href="/blogs/program">Program</a>
         </div>
         <div class="grid-item text-align-center">
           <a href="/blogs/donations">Donations</a>

--- a/snippets/article-donations.liquid
+++ b/snippets/article-donations.liquid
@@ -1,0 +1,4 @@
+<div class="article grid-item item-s-12 margin-bottom-small text-align-center">
+  <h2 class="margin-bottom-tiny">{{ article.title }}</h2>
+  {{ article.content }}
+</div>

--- a/snippets/article-program.liquid
+++ b/snippets/article-program.liquid
@@ -1,0 +1,10 @@
+<div class="article grid-item item-s-12 item-m-6 padding-top-small padding-bottom-small">
+  {% if article.image %}
+  <div class="margin-bottom-micro">
+    <img src="{{ article | img_url: 'grande' }}" />
+  </div>
+  {% endif %}
+  <span>{{ article.published_at | date: '%m/%d/%C%y' }}</span>
+  <h2 class="font-uppercase margin-bottom-tiny">{{ article.title }}</h2>
+  {{ article.content }}
+</div>

--- a/templates/article.liquid
+++ b/templates/article.liquid
@@ -1,4 +1,4 @@
-<section class="container">
+<section id="article">
   <div class="grid-row">
     <div class="grid-item item-s-12 item-m-6">
       <h2>{{ article.title }}</h2>
@@ -6,4 +6,4 @@
       {{ article.content }}
     </div>
   </div>
-</div>
+</section>

--- a/templates/blog.liquid
+++ b/templates/blog.liquid
@@ -34,8 +34,7 @@
 
     {% else %}
       <div class="article grid-item">
-        <h2>{{ article.title }}</h2>
-        {{ article.content }}
+        <h2><a href="{{ article.url }}">{{ article.title }}</a></h2>
       </div>
     {% endif %}
     {% endfor %}

--- a/templates/blog.liquid
+++ b/templates/blog.liquid
@@ -1,11 +1,44 @@
-<section class="container">
-  <div class="grid-row">
-    <div class="grid-item item-s-12 item-m-6">
-      <ul>
-        {% for article in blog.articles %}
-        <li><a href="{{ article.url }}">{{ article.title }}</a></li>
-        {% endfor %}
-      </ul>
+{% if blog.title == 'Donations' %}
+  {% assign month = '' %}
+  {% assign year = '' %}
+{% endif %}
+<section id="blog">
+  <h1 class="font-uppercase text-align-center padding-top-small padding-bottom-small">{{ blog.title }}</h1>
+  <div class="container">
+    <div class="grid-row">
+    {% if blog.title == 'Donations' %}
+      <div class="u-hidden">
+    {% endif %}
+
+    {% for article in blog.articles %}
+
+    {% if blog.title == 'Program' %}
+      {% include 'article-program' %}
+
+    {% else if blog.title == 'Donations' %}
+      {% assign newMonth = article.published_at | date: '%B' %}
+      {% assign newYear = article.published_at | date: '%y' %}
+
+      {% if month != newMonth or year != newYear %}
+        {% assign month = newMonth %}
+        {% assign year = newYear %}
+      </div> <!-- close previous month, or u-hidden div from above -->
+      <div class="donation-holder grid-item item-s-12 item-m-6 grid-row no-gutter font-uppercase">
+        <div class="donation-month grid-item item-s-12 item-m-6 text-align-center padding-top-small padding-bottom-small margin-bottom-small">
+          {{ month }} '{{ year }}
+        </div>
+        {% include 'article-donations' %}
+      {% else %}
+        {% include 'article-donations' %}
+      {% endif %}
+
+    {% else %}
+      <div class="article grid-item">
+        <h2>{{ article.title }}</h2>
+        {{ article.content }}
+      </div>
+    {% endif %}
+    {% endfor %}
     </div>
   </div>
 </div>


### PR DESCRIPTION
scaffolds blog pages with program and donations article types.

see pages 4 & 5 of web design pdf for most recent design

there are some clarifications (not reflected in pdf) that i discussed with client on the phone:
- donations blog only shows months w/ published donations. (not the empty months as in pdf)
- donations months can have multiple donations
- donations month header includes year in '18 format
- "View Receipt" links to pdf. these pdf files are added to shopify admin via Settings > Files, and then the url is cp into Donation blog post content
  - see: https://help.shopify.com/manual/sell-online/online-store/file-uploads

I think these article items may need masonry layout on blog page. that will come later tho